### PR TITLE
Fix kedro 0.18.3 recipe dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 596959f80ebbeef06234eeb0f2f8916ed7fdc8c0af5a5aae55835a2c88dd914c
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,7 +68,6 @@ extra:
     - marcelotrevisani
     - yetudada
     - idanov
-    - MerelTheisenQB
     - AntonyMilneQB
     - AhdraMeraliQB
     - jmholzer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - click <9.0
     - cookiecutter >=2.1.1,<3.0
     - dynaconf >=3.1.2, <4.0
-    - fsspec >=2021.4,<=2022.1
+    - fsspec >=2021.4,<=2022.7.1
     - gitpython >=3.0,<4.0
     - importlib_metadata >=3.6
     - importlib_resources >=1.3
@@ -38,13 +38,12 @@ requirements:
     - pluggy >=1.0,<1.1
     - python >=3.7,<3.11
     - python-json-logger >=2.0.0,<3.0.0
-    - pyyaml >=4.2,<6.0
+    - pyyaml >=4.2,<7.0
     - rich >=12.0,<13.0
     - rope >=0.21.0,<0.22.0
     - setuptools >=38.0
     - toml >=0.10,<0.11
     - toposort >=1.5,<2.0
-    - git
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,6 +68,7 @@ extra:
     - marcelotrevisani
     - yetudada
     - idanov
+    - merelcht
     - AntonyMilneQB
     - AhdraMeraliQB
     - jmholzer


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

**Relevant Info below:**

Fixes 3 minor issues, and updates recipe maintainers

1. git is a dependency of gitpython # Refer https://github.com/conda-forge/gitpython-feedstock/blob/main/recipe/meta.yaml
   - Removed git
2. pyyaml upper bound should be 7.0 # Refer https://github.com/kedro-org/kedro/blob/4db0ae3be611f60f3c98da2501364d5549c784f2/requirements.txt#L14
    - PyYAML>=4.2, <7.0
3. fsspec upper bound should be 2022.7.1 # Refer https://github.com/kedro-org/kedro/blob/4db0ae3be611f60f3c98da2501364d5549c784f2/requirements.txt#L7
    - fsspec>=2021.4, <=2022.7.1
4. conda-smithy rerender complained about MerelTheisenQB # Refer > Recipe maintainer "MerelTheisenQB" does not exist
    - Removed recipe maintainer "MerelTheisenQB"



