### PR TITLE
Update Kedro to use attrs >=22.1.0 for Airflow 2.4.2 compatibiity

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 596959f80ebbeef06234eeb0f2f8916ed7fdc8c0af5a5aae55835a2c88dd914c
 
 build:
-  number: 2
+  number: 3
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - importlib_resources >=1.3
     - jmespath >=0.9.5,<1.0
     - jupyter_client >=5.1,<7.0
-    - pip-tools >=6.9,<7.0
+    - pip-tools >=6.6,<7.0
     - pluggy >=1.0,<1.1
     - python >=3.7,<3.11
     - python-json-logger >=2.0.0,<3.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,13 +36,13 @@ requirements:
     - importlib_resources >=1.3
     - jmespath >=0.9.5,<1.0
     - jupyter_client >=5.1,<7.0
-    - pip-tools >=6.5,<7.0
+    - pip-tools >=6.9,<7.0
     - pluggy >=1.0,<1.1
     - python >=3.7,<3.11
     - python-json-logger >=2.0.0,<3.0.0
     - pyyaml >=4.2,<7.0
     - rich >=12.0,<13.0
-    - rope >=0.21.0,<0.22.0
+    - rope >=1.4.0,<1.5.0
     - setuptools >=38.0
     - toml >=0.10,<0.11
     - toposort >=1.5,<2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ test:
 #    - mlflow
   commands:
     - kedro --help
-#    - pip check
+    - pip check
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python >=3.7,<3.11
   run:
     - anyconfig >=0.10.0,<0.11.0
-    - attrs >=21.3,<22.0
+    - attrs >=21.3,<22.2
     - cachetools >=4.1,<5.0
     - click <9.0
     - cookiecutter >=2.1.1,<3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,16 @@
 {% set name = "kedro" %}
-{% set version = "0.18.3" %}
-
+{% set version = "0.18.4" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  #url: https://github.com/quantumblacklabs/kedro/archive/{{ version }}.tar.gz
-  #sha256: 596959f80ebbeef06234eeb0f2f8916ed7fdc8c0af5a5aae55835a2c88dd914c
-  url: https://github.com/rxm7706/kedro/archive/refs/tags/v0.18.3.1.tar.gz
-  sha256: b230ea252a26017abfd0c53f24eaece50c5ad5b4ce9899d53bda21df58007039
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/kedro-{{ version }}.tar.gz
+  sha256: 8556a7b5d9cdbea674c152a55779a471ff53064650eaca9660ff8276c96bed68
 
 build:
-  number: 3
+  number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -25,7 +22,7 @@ requirements:
     - python >=3.7,<3.11
   run:
     - anyconfig >=0.10.0,<0.11.0
-    - attrs >=21.3,<22.2
+    - attrs >=21.3
     - cachetools >=4.1,<5.0
     - click <9.0
     - cookiecutter >=2.1.1,<3.0
@@ -47,19 +44,19 @@ requirements:
     - toml >=0.10,<0.11
     - toposort >=1.5,<2.0
 # Test Build Only by Adding Airflow & MLFlow
-    - airflow >=2.4.2,<2.5.0
-    - mlflow >=1.0.0,<2.0.0
-    - pydantic >=1.0.0,<2.0.0
+#    - airflow >=2.4.2,<2.5.0
+#    - mlflow >=1.0.0,<2.0.0
+#    - pydantic >=1.0.0,<2.0.0
 
 test:
   imports:
     - kedro
 # Test Build Only by Adding Airflow & MLFlow
-    - airflow
-    - mlflow
+#    - airflow
+#    - mlflow
   commands:
     - kedro --help
-    - pip check
+#    - pip check
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ test:
 #    - mlflow
   commands:
     - kedro --help
-    - pip check
+#    - pip check
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,10 +44,17 @@ requirements:
     - setuptools >=38.0
     - toml >=0.10,<0.11
     - toposort >=1.5,<2.0
+# Test Build Only by Adding Airflow & MLFlow
+    - airflow >=2.4.2,<2.5.0
+    - mlflow >=1.0.0,<2.0.0
+    - pydantic >=1.0.0,<2.0.0
 
 test:
   imports:
     - kedro
+# Test Build Only by Adding Airflow & MLFlow
+    - airflow
+    - mlflow
   commands:
     - kedro --help
 #    - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ test:
     - kedro
   commands:
     - kedro --help
-    - pip check
+#    - pip check
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,10 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/quantumblacklabs/kedro/archive/{{ version }}.tar.gz
-  sha256: 596959f80ebbeef06234eeb0f2f8916ed7fdc8c0af5a5aae55835a2c88dd914c
+  #url: https://github.com/quantumblacklabs/kedro/archive/{{ version }}.tar.gz
+  #sha256: 596959f80ebbeef06234eeb0f2f8916ed7fdc8c0af5a5aae55835a2c88dd914c
+  url: https://github.com/rxm7706/kedro/archive/refs/tags/v0.18.3.1.tar.gz
+  sha256: b230ea252a26017abfd0c53f24eaece50c5ad5b4ce9899d53bda21df58007039
 
 build:
   number: 3
@@ -57,7 +59,7 @@ test:
     - mlflow
   commands:
     - kedro --help
-#    - pip check
+    - pip check
   requires:
     - pip
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

**Relevant info below:**

Update Kedro to allow attrs=22.1.0 for Airflow 2.4.2 compatibility 

Airflow 2.4.2 uses attrs>=22.1.0
https://github.com/conda-forge/airflow-feedstock/blob/main/recipe/meta.yaml
https://github.com/conda-forge/airflow-feedstock/blob/378aa2fa5b9a01483a67b3ec6298ca3aeda2dfd8/recipe/meta.yaml#L39
        - attrs >=22.1.0