### PR TITLE
Update Kedro to Version 0.18.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,16 @@
 {% set name = "kedro" %}
-{% set version = "0.18.3" %}
-
+{% set version = "0.18.4" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/quantumblacklabs/kedro/archive/{{ version }}.tar.gz
-  sha256: 596959f80ebbeef06234eeb0f2f8916ed7fdc8c0af5a5aae55835a2c88dd914c
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/kedro-{{ version }}.tar.gz
+  sha256: 8556a7b5d9cdbea674c152a55779a471ff53064650eaca9660ff8276c96bed68
 
 build:
-  number: 2
+  number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -23,7 +22,7 @@ requirements:
     - python >=3.7,<3.11
   run:
     - anyconfig >=0.10.0,<0.11.0
-    - attrs >=21.3,<22.0
+    - attrs >=21.3
     - cachetools >=4.1,<5.0
     - click <9.0
     - cookiecutter >=2.1.1,<3.0
@@ -34,13 +33,13 @@ requirements:
     - importlib_resources >=1.3
     - jmespath >=0.9.5,<1.0
     - jupyter_client >=5.1,<7.0
-    - pip-tools >=6.5,<7.0
+    - pip-tools >=6.6,<7.0
     - pluggy >=1.0,<1.1
     - python >=3.7,<3.11
     - python-json-logger >=2.0.0,<3.0.0
     - pyyaml >=4.2,<7.0
     - rich >=12.0,<13.0
-    - rope >=0.21.0,<0.22.0
+    - rope >=1.4.0,<1.5.0
     - setuptools >=38.0
     - toml >=0.10,<0.11
     - toposort >=1.5,<2.0
@@ -50,7 +49,10 @@ test:
     - kedro
   commands:
     - kedro --help
-    - pip check
+# Disabled pip check because of pip-tools and rope
+# pip requirements.txt is has requirement pip-tools~=6.10, but conda has only pip-tools 6.6.2
+# pip requirements.txt is has requirement rope~=1.5.1, but conda has only rope 1.4.0.
+#    - pip check
   requires:
     - pip
 


### PR DESCRIPTION
 Disabled pip check because of pip-tools and rope # pip requirements.txt is has requirement pip-tools~=6.10, but conda has only pip-tools 6.6.2 # pip requirements.txt is has requirement rope~=1.5.1, but conda has only rope 1.4.0.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
