### PR TITLE
loosen omegaconf for py37

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: eb972b4b78b980e621837e59af72083f9fcc8fe4da8dd70d1e1d5ba66df790f8
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -34,7 +34,7 @@ requirements:
     - jmespath >=0.9.5,<1.0
     - jupyter_client >=5.1,<7.0
     - more-itertools >8.14.0,<=9.0
-    - omegaconf >=2.2.1, <=2.3
+    - omegaconf >=2.1.1, <=2.3
     - pip-tools >=6.6
     - pluggy >=1.0,<1.1
     - python >=3.7,<3.11


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
omegaconf depdency on antlr4-python3-runtime since version 2.1.1 for Python 3.7 is preventing installation and upgrade to Kedro 0.18.5, lowering the pin on omegaconf  does not seem to impact kedro, but allows conda install to succeed. 
    - omegaconf >=2.2.1, <=2.3
    - omegaconf >=2.1.1, <=2.3