### PR TITLE
Remove Jupyter_Server & python-json-logger

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 226174c02362f1f1fc3ddd24ba22d39feb1e3a89c3ae4fbb8585c324f39a1eeb
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -23,6 +23,7 @@ requirements:
   run:
     - anyconfig >=0.10.0,<0.11.0
     - attrs >=21.3
+    - build
     - cachetools >=4.1,<6.0
     - click <9.0
     - cookiecutter >=2.1.1,<3.0
@@ -32,15 +33,13 @@ requirements:
     - importlib_metadata >=3.6
     - importlib_resources >=1.3
     - jmespath >=0.9.5,<1.0
-    - jupyter_client >=5.1,<7.0
     - more-itertools >8.14.0,<=9.0
     - omegaconf >=2.1.1, <=2.3
-    - pip-tools >=6.6
+    - pip-tools >=6.5
     - pluggy >=1.0,<1.1
     - python >=3.7,<3.11
-    - python-json-logger >=2.0.0,<3.0.0
     - pyyaml >=4.2,<7.0
-    - rich >=12.0,<13.0
+    - rich >=12.0,<14.0
     - rope >=1.4.0
     - setuptools >=38.0
     - toml >=0.10,<0.11


### PR DESCRIPTION
kedro removed jupyter_client and python-json-logger from requirements.txt

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
https://github.com/conda-forge/kedro-feedstock/issues/37
<!--
Please add any other relevant info below:
-->
build was added recently and matching match pip-tools and rich limits