### PR TITLE
PiP/pyproject.toml and Conda/Meta.yaml Sync

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @AhdraMeraliQB @NeroOkwa @SajidAlamQB @antonymilne @idanov @jmholzer @marcelotrevisani @merelcht @noklam @yetudada
+* @AhdraMeraliQB @DimedS @NeroOkwa @SajidAlamQB @idanov @lrcouto @marcelotrevisani @merelcht @noklam @yetudada

--- a/README.md
+++ b/README.md
@@ -150,11 +150,11 @@ Feedstock Maintainers
 =====================
 
 * [@AhdraMeraliQB](https://github.com/AhdraMeraliQB/)
+* [@DimedS](https://github.com/DimedS/)
 * [@NeroOkwa](https://github.com/NeroOkwa/)
 * [@SajidAlamQB](https://github.com/SajidAlamQB/)
-* [@antonymilne](https://github.com/antonymilne/)
 * [@idanov](https://github.com/idanov/)
-* [@jmholzer](https://github.com/jmholzer/)
+* [@lrcouto](https://github.com/lrcouto/)
 * [@marcelotrevisani](https://github.com/marcelotrevisani/)
 * [@merelcht](https://github.com/merelcht/)
 * [@noklam](https://github.com/noklam/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - anyconfig >=0.10.0,<1.0.0
     - attrs >=21.3,<24.0
     - python-build >=0.7.0,<1.0.0
-    - cachetools >=5.3,<6.0
+    - cachetools >=4.1,<6.0
     - click >=7.0,<9.0
     - cookiecutter >=2.1.1,<3.0
     - dynaconf >=3.1.2,<4.0
@@ -34,7 +34,7 @@ requirements:
     - importlib-metadata >=3.6,<7.0.0
     - importlib_resources >=1.3,<7.0.0
     - jmespath >=0.9.5,<2.0.0  # 1.0.1
-    - more-itertools >=8.14,<11
+    - more-itertools >=8.14.0,<11
     - omegaconf >=2.1.1,<3.0.0
     - parse >=1.19.0,<=2.0.0
     - pip-tools >=6.5,<8.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,31 +21,31 @@ requirements:
     - pip
     - python >=3.7,<3.11
   run:
-    - anyconfig >=0.10.0,<1.0.0
-    - attrs >=21.3,<24.0
-    - python-build >=0.7.0,<1.0.0
-    - cachetools >=4.1,<6.0
+    - anyconfig >=0.10.0
+    - attrs >=21.3
+    - python-build >=0.7.0
+    - cachetools >=4.1
     - click >=7.0,<9.0
     - cookiecutter >=2.1.1,<3.0
     - dynaconf >=3.1.2,<4.0
-    - fsspec >=2021.4,<2024.1
-    - gitpython >=3.0,<4.0
+    - fsspec >=2021.4
+    - gitpython >=3.0
     - importlib_metadata >=3.6,<7.0.0
     - importlib-metadata >=3.6,<7.0.0
     - importlib_resources >=1.3,<7.0.0
-    - jmespath >=0.9.5,<2.0.0  # 1.0.1
-    - more-itertools >=8.14.0,<11
-    - omegaconf >=2.1.1,<3.0.0
-    - parse >=1.19.0,<=2.0.0
-    - pip-tools >=6.5,<8.0.0
-    - pluggy >=1.0,<2.0
+    - jmespath >=0.9.5
+    - more-itertools >=8.14.0
+    - omegaconf >=2.1.1
+    - parse >=1.19.0
+    - pip-tools >=6.5
+    - pluggy >=1.0
     - python >=3.7,<3.11
     - pyyaml >=4.2,<7.0
     - rich >=12.0,<14.0
     - rope >=0.21,<2.0
-    - setuptools >=38.0,<70.0.0
-    - toml >=0.10.0,<1.0.0
-    - toposort >=1.5,<2.0
+    - setuptools >=38.0
+    - toml >=0.10.0
+    - toposort >=1.5
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - attrs >=21.3
     - python-build >=0.7.0
     - cachetools >=4.1
-    - click >=7.0,<9.0
+    - click >=4.0
     - cookiecutter >=2.1.1,<3.0
     - dynaconf >=3.1.2,<4.0
     - fsspec >=2021.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "kedro" %}
-{% set version = "0.18.12" %}
+{% set version = "0.18.13" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/kedro-{{ version }}.tar.gz
-  sha256: 5bd995dc710507427097488200f9f40ac8fb5085bec415ae6dd2335a53ffbf49
+  sha256: 89c6684fb6c530300759fc58d93ee55162bbae949c04b5a7fdd234e9cf117149
 
 build:
   number: 1
@@ -38,7 +38,7 @@ requirements:
     - omegaconf >=2.1.1
     - parse >=1.19.0
     - pip-tools >=6.5
-    - pluggy >=1.0
+    - pluggy >=1.0,<1.3 # TODO: Uncap when dropping Python 3.7 support, see https://github.com/kedro-org/kedro/issues/2979
     - python >=3.7,<3.11
     - pyyaml >=4.2,<7.0
     - rich >=12.0,<14.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - importlib-metadata >=3.6,<7.0.0
     - importlib_resources >=1.3,<7.0.0
     - jmespath >=0.9.5,<2.0.0  # 1.0.1
-    - more-itertools >8.14.0,<10.0
+    - more-itertools >=8.14,<11
     - omegaconf >=2.1.1,<3.0.0
     - parse >=1.19.0,<=2.0.0
     - pip-tools >=6.5,<8.0.0
@@ -42,7 +42,7 @@ requirements:
     - python >=3.7,<3.11
     - pyyaml >=4.2,<7.0
     - rich >=12.0,<14.0
-    - rope >=1.4.0,<2.0
+    - rope >=0.21,<2.0
     - setuptools >=38.0,<70.0.0
     - toml >=0.10.0,<1.0.0
     - toposort >=1.5,<2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,9 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.7,<3.11
+    - python >=3.7
   run:
+    - python >=3.7
     - anyconfig >=0.10.0
     - attrs >=21.3
     - python-build >=0.7.0
@@ -39,7 +40,6 @@ requirements:
     - parse >=1.19.0
     - pip-tools >=6.5
     - pluggy >=1.0,<1.3 # TODO: Uncap when dropping Python 3.7 support, see https://github.com/kedro-org/kedro/issues/2979
-    - python >=3.7,<3.11
     - pyyaml >=4.2,<7.0
     - rich >=12.0,<14.0
     - rope >=0.21,<2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,11 @@ source:
   sha256: 89c6684fb6c530300759fc58d93ee55162bbae949c04b5a7fdd234e9cf117149
 
 build:
-  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - kedro = kedro.framework.cli:main
+  number: 1
 
 requirements:
   host:
@@ -52,10 +52,7 @@ test:
     - kedro
   commands:
     - kedro --help
-# Disabled pip check because of pip-tools and rope
-# pip requirements.txt is has requirement pip-tools~=6.10, but conda has only pip-tools 6.6.2
-# pip requirements.txt is has requirement rope~=1.5.1, but conda has only rope 1.4.0.
-#    - pip check
+    - pip check
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5bd995dc710507427097488200f9f40ac8fb5085bec415ae6dd2335a53ffbf49
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -21,29 +21,30 @@ requirements:
     - pip
     - python >=3.7,<3.11
   run:
-    - anyconfig >=0.10.0,<0.11.0
-    - attrs >=21.3
-    - python-build
+    - anyconfig >=0.10.0,<1.0.0
+    - attrs >=21.3,<24.0
+    - python-build >=0.7.0,<1.0.0
     - cachetools >=5.3,<6.0
-    - click <9.0
+    - click >=7.0,<9.0
     - cookiecutter >=2.1.1,<3.0
-    - dynaconf >=3.1.2, <4.0
+    - dynaconf >=3.1.2,<4.0
     - fsspec >=2021.4,<2024.1
     - gitpython >=3.0,<4.0
-    - importlib_metadata >=3.6
-    - importlib_resources >=1.3
-    - jmespath >=0.9.5,<1.0
-    - more-itertools >8.14.0,<=9.0
-    - omegaconf >=2.1.1, <=2.3
-    - parse >=1.19.0, <=2.0
-    - pip-tools >=6.5
-    - pluggy >=1.0,<1.1
+    - importlib_metadata >=3.6,<7.0.0
+    - importlib-metadata >=3.6,<7.0.0
+    - importlib_resources >=1.3,<7.0.0
+    - jmespath >=0.9.5,<2.0.0  # 1.0.1
+    - more-itertools >8.14.0,<10.0
+    - omegaconf >=2.1.1,<3.0.0
+    - parse >=1.19.0,<=2.0.0
+    - pip-tools >=6.5,<8.0.0
+    - pluggy >=1.0,<2.0
     - python >=3.7,<3.11
     - pyyaml >=4.2,<7.0
     - rich >=12.0,<14.0
-    - rope >=1.4.0
-    - setuptools >=38.0
-    - toml >=0.10,<0.11
+    - rope >=1.4.0,<2.0
+    - setuptools >=38.0,<70.0.0
+    - toml >=0.10.0,<1.0.0
     - toposort >=1.5,<2.0
 
 test:


### PR DESCRIPTION
### Summary 
There is no easy way to keep pip builds and conda builds in sync - across customers, developers (1st party and 3rd Party Plugins)

### Background

1. Kedro has a strong unit test, E2E test suite with very high coverage - Making it generally easier to change versions and test for compatibility. 
2. Kedro Development uses PiP, Kedro distribution is via both PyPI/Pip and conda/conda-forge - giving everyone the highest flexibility. 
3. Kedro ecosystem is not a monorepo by deisgn; first party plugins (kedro-viz, Kedro-airflow) and 3rd party plugins (Kedro-ML, Kedro-VertexAI) need to have non conflicting requirements to be able to be used in conjunction. To achieve this eventual consistency across plugins and packaging types (conda & pip) - Kedro needs to support a broader range of package versions, and provide consistency on kedro installation across conda & pip. 
  - One e.g. is semver - Kedro-Viz supports semver>=2.10  # Needs to be at least 2.10.0 to make use of `VersionInfo.match`. but Kedro-VertexAI uses semver = "~=2.10".
  - As customers try to use Kedro, Kedro-Viz, Kedro-Airflow, Kedro-MLFlow with Airflow, GCP, Azure, AWS and MLFlow; dependencies need to be managed with the version dependencies of Airflow, MLFlow, and cloud SDKs that are much more complex. 

### Problem Description
1. Most conda packages are built off PyPI distributions - so PiP versions will generally be ahead/newer than conda. 
2. If the conda feedstock maintainer doesn't merge the PR to update conda packages - Conda can fall behind pip by weeks/months/years. 
3. pip allows "'~='" which can be both over restrictive (e.g. "anyconfig  like 0.10.0" is currently used in requirements, but anyconfig version 0.13.0 was released in April 2022 ), in turn setting "anyconfig  like 0.13.0" is also detrimental, forcing compatibility off all pacakges in a virtual env, or conda env to upgrade to version 0.13.0 when 0.10.0 would probably work just fine. 
4. Keeping both PiP and conda requirements in the format of >=/< e.g. "PyYAML>=4.2,<7.0", are very readable and easily comparable - ensuing compatibility and consistent Virtual env & Conda Envs. 

### Considerations

1. Kedro is now probably running / used in more places than maintainers know about ; 40+ releases, 4+ Years of OSS releases, 1+ Yr of LF AI & Data. Supporting broader ranges of compatibility (e.g. "PyYAML>=4.2, <7.0", & "cookiecutter>=2.1.1, <3.0",) is beneficial to customers & 3rd party developers.
2. Customers are not able to upgrade package versions as quickly as Kedro itself -  if we upgrade and only support latest versions of pip packages recommended by dependabot. 
3. Models in production are generally not updated frequently (i.e. package versions cannot be constantly upgraded) and Kedro doesn't prescribe LTS / Vulnerability life cycle management yet. 
4. enabling pip check on conda meta.yaml requires analysis of conda packages available, requires not updating minimum versions too quickly and allows kedro & plugins to stay compatible with base kedro, across conda & PiP packaging.

### An Initial Analysis shows

1. Because of Kedro's use of only a few and well maintained packages - PiP and conda package availability have almost 100% availability (except for PyYAML where pip has 6.0.1 and conda has only 6.0)
2. It might be possible to sync PiP/pyproject.toml and Conda/Meta.yaml and address a lot future dependency / compatibility issues with a few changes / some focused testing and builds on pyproject.toml and conda-feedstock
3. pyproject.toml will eventually be the driver for consistency - But its easier to propose and demonstrate an initial version as a draft conda-feedstock allowing for maintainer feedback, test via import kedro and pip check.
4. If the first drafts of the feedstock show promise, common requirements /updates and fixes can be raised as a PR to pyproject.toml

![image](https://github.com/conda-forge/kedro-feedstock/assets/95496360/62bddc8e-9eb7-4e28-8220-379bed302362)


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
